### PR TITLE
1. Add the Categories property to TelegramLoggerOptions. 2. Fix datetime format. 3. Upgrade Telegram.Bot to 16.0.2.

### DIFF
--- a/src/X.Extensions.Logging.Telegram/TelegramLogger.cs
+++ b/src/X.Extensions.Logging.Telegram/TelegramLogger.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Microsoft.Extensions.Logging;
 
 namespace X.Extensions.Logging.Telegram
@@ -6,11 +7,13 @@ namespace X.Extensions.Logging.Telegram
     public class TelegramLogger : ILogger
     {
         private readonly TelegramLoggerProcessor _queueProcessor;
+        private readonly string _category;
         private readonly TelegramMessageFormatter _formatter;
 
-        internal TelegramLogger(string name, TelegramLoggerOptions options, TelegramLoggerProcessor loggerProcessor)
+        internal TelegramLogger(string name, TelegramLoggerOptions options, TelegramLoggerProcessor loggerProcessor, string category)
         {
             _queueProcessor = loggerProcessor;
+            _category = category;
             _formatter = new TelegramMessageFormatter(options, name);
 
             Options = options ?? throw new ArgumentNullException(nameof(options));
@@ -40,7 +43,9 @@ namespace X.Extensions.Logging.Telegram
             _queueProcessor.EnqueueMessage(message);
         }
 
-        public bool IsEnabled(LogLevel logLevel) => logLevel >= Options.LogLevel;
+        public bool IsEnabled(LogLevel logLevel) => 
+            logLevel > Options.LogLevel || 
+            logLevel == Options.LogLevel && (Options.Categories == null || Options.Categories.Contains(_category));
 
         public IDisposable BeginScope<TState>(TState state) => default;
     }

--- a/src/X.Extensions.Logging.Telegram/TelegramLoggerOptions.cs
+++ b/src/X.Extensions.Logging.Telegram/TelegramLoggerOptions.cs
@@ -9,5 +9,6 @@ namespace X.Extensions.Logging.Telegram
         public string ChatId { get; set; }
         public bool UseEmoji { get; set; } = true;
         public string Source { get; set; }
+        public string[] Categories { get; set; }
     }
 }

--- a/src/X.Extensions.Logging.Telegram/TelegramLoggerProvider.cs
+++ b/src/X.Extensions.Logging.Telegram/TelegramLoggerProvider.cs
@@ -19,7 +19,7 @@ namespace X.Extensions.Logging.Telegram
 
         public ILogger CreateLogger(string categoryName)
         {
-            return _loggers.GetOrAdd(categoryName, name => new TelegramLogger(name, _options, _telegramLoggerProcessor));
+            return _loggers.GetOrAdd(categoryName, name => new TelegramLogger(name, _options, _telegramLoggerProcessor, categoryName));
         }
 
         public void Dispose() => _loggers.Clear();

--- a/src/X.Extensions.Logging.Telegram/TelegramMessageFormatter.cs
+++ b/src/X.Extensions.Logging.Telegram/TelegramMessageFormatter.cs
@@ -29,21 +29,19 @@ namespace X.Extensions.Logging.Telegram
                 return string.Empty;
             }
             
-            var level = _options.UseEmoji ? ToEmoji(logLevel) : ToString(logLevel);
-
             var sb = new StringBuilder();
 
-            if (_options.UseEmoji)
-            {
-                sb.Append($"{level} *{DateTime.Now:hh:mm:ss}* {message}");
-            }
-            else
-            {
-                sb.Append($"*{DateTime.Now:hh:mm:ss}* {level}: {message}");    
-            }
+            sb.Append(_options.UseEmoji
+                ? $"{ToEmoji(logLevel)} *{DateTime.Now:HH:mm:ss}* {ToString(logLevel)}"
+                : $"*{DateTime.Now:HH:mm:ss}* {ToString(logLevel)}");
             
             sb.AppendLine();
-            
+            sb.Append($"`{_name}`");
+
+            sb.AppendLine();
+            sb.AppendLine($"Message: {message}");
+            sb.AppendLine();
+
             if (exception != null)
             {
                 sb.AppendLine();
@@ -51,11 +49,10 @@ namespace X.Extensions.Logging.Telegram
                 sb.AppendLine();
             }
 
-            sb.Append($"_Initiator : {_name}_");
-            
             if (!string.IsNullOrWhiteSpace(_options.Source))
             {
-                sb.Append($"\t\t\t_Source: {_options.Source}_");
+                sb.AppendLine();
+                sb.Append($"_Source: {_options.Source}_");
             }
             
             sb.AppendLine();

--- a/src/X.Extensions.Logging.Telegram/X.Extensions.Logging.Telegram.csproj
+++ b/src/X.Extensions.Logging.Telegram/X.Extensions.Logging.Telegram.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
         <LangVersion>9</LangVersion>
         <Authors>Andrew Gubskiy</Authors>
         <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
@@ -14,12 +13,13 @@
         <Description>Telegram logging provider</Description>
         <RepositoryType>git</RepositoryType>
         <Version>1.0.1.5</Version>
+        <TargetFramework>netstandard2.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
       <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
-      <PackageReference Include="Telegram.Bot" Version="16.0.0" />
+      <PackageReference Include="Telegram.Bot" Version="16.0.2" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
1. Add the Categories property to TelegramLoggerOptions to specify messages categoris. 
2. Fix date time format. 
3. Upgrade Telegram.Bot to 16.0.2.
4. Fix structure of message.