### PR TITLE
Replace markdown with html

### DIFF
--- a/src/X.Extensions.Logging.Telegram/TelegramMessageFormatter.cs
+++ b/src/X.Extensions.Logging.Telegram/TelegramMessageFormatter.cs
@@ -32,11 +32,11 @@ namespace X.Extensions.Logging.Telegram
             var sb = new StringBuilder();
 
             sb.Append(_options.UseEmoji
-                ? $"{ToEmoji(logLevel)} *{DateTime.Now:HH:mm:ss}* {ToString(logLevel)}"
-                : $"*{DateTime.Now:HH:mm:ss}* {ToString(logLevel)}");
-            
+                ? $"{ToEmoji(logLevel)} <b>{DateTime.Now:HH:mm:ss}</b> {ToString(logLevel)}"
+                : $"<b>{DateTime.Now:HH:mm:ss}</b> {ToString(logLevel)}");
+
             sb.AppendLine();
-            sb.Append($"`{_name}`");
+            sb.Append($"<pre>{_name}</pre>");
 
             sb.AppendLine();
             sb.AppendLine($"Message: {message}");
@@ -45,14 +45,14 @@ namespace X.Extensions.Logging.Telegram
             if (exception != null)
             {
                 sb.AppendLine();
-                sb.AppendLine($"`{exception}`");
+                sb.AppendLine($"<pre>{exception}</pre>");
                 sb.AppendLine();
             }
 
             if (!string.IsNullOrWhiteSpace(_options.Source))
             {
                 sb.AppendLine();
-                sb.Append($"_Source: {_options.Source}_");
+                sb.Append($"<i>Source: {_options.Source}</i>");
             }
             
             sb.AppendLine();

--- a/src/X.Extensions.Logging.Telegram/TelegramMessageFormatter.cs
+++ b/src/X.Extensions.Logging.Telegram/TelegramMessageFormatter.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Net;
 using System.Text;
+
 using Microsoft.Extensions.Logging;
 
 namespace X.Extensions.Logging.Telegram
@@ -45,7 +47,7 @@ namespace X.Extensions.Logging.Telegram
             if (exception != null)
             {
                 sb.AppendLine();
-                sb.AppendLine($"<pre>{exception}</pre>");
+                sb.AppendLine($"<pre>{WebUtility.HtmlEncode(exception.ToString())}</pre>");
                 sb.AppendLine();
             }
 

--- a/src/X.Extensions.Logging.Telegram/TelegramWriter.cs
+++ b/src/X.Extensions.Logging.Telegram/TelegramWriter.cs
@@ -23,6 +23,6 @@ namespace X.Extensions.Logging.Telegram
         }
 
         public async Task Write(string message) =>
-            await _client.SendTextMessageAsync(_chatId, message, ParseMode.Markdown);
+            await _client.SendTextMessageAsync(_chatId, message, ParseMode.Html);
     }
 }

--- a/tests/X.Extensions.Logging.Telegram.Tests/TelegramLoggingTests.cs
+++ b/tests/X.Extensions.Logging.Telegram.Tests/TelegramLoggingTests.cs
@@ -1,4 +1,6 @@
-using System;
+using System.Net;
+using System.Text.Encodings.Web;
+
 using Microsoft.Extensions.Logging;
 using NUnit.Framework;
 
@@ -13,7 +15,7 @@ namespace X.Extensions.Logging.Telegram.Tests
         }
 
         [Test]
-        public void Test1()
+        public void Test_MessageFormatter_MessageNotNull()
         {
             var options = new TelegramLoggerOptions
             {
@@ -28,6 +30,23 @@ namespace X.Extensions.Logging.Telegram.Tests
             var message = formatter.Format(LogLevel.Warning, new EventId(), "Message", null, (s, _) => s);
 
             Assert.NotNull(message);
+        }
+
+        [TestCase("<p style=\"font-family='Lucida Console'\">Exception message description</p>")]
+        [TestCase("<p style=\"font-family='Lucida Console';width:100%\">Exception <br/><i><b>message</b></i> description</p>")]
+        public void ExceptionDescriptionWithRawHtmlTest(string description)
+        {
+            var encodedHtml = WebUtility.HtmlEncode(description);
+
+            var containsRawHtml = encodedHtml.Contains("<p style=\"font-family='Lucida Console'\">") ||
+                                        encodedHtml.Contains("</p>") ||
+                                        encodedHtml.Contains("<br/>") ||
+                                        encodedHtml.Contains("<i>") ||
+                                        encodedHtml.Contains("</i>") ||
+                                        encodedHtml.Contains("<b>") ||
+                                        encodedHtml.Contains("</b>");
+
+            Assert.False(containsRawHtml);
         }
     }
 }


### PR DESCRIPTION
Markdown formatting was replaced with an HTML one to avoid misformatting caused by stack trace's special characters

![image](https://user-images.githubusercontent.com/67170413/140554183-04696eed-77c8-4ada-b253-0fd11992746a.png)
![image](https://user-images.githubusercontent.com/67170413/140554121-a170eef6-b0bd-4a17-b047-2baa8cf9fa2e.png)
